### PR TITLE
E2005. Show bookmark count from topic sign up sheet

### DIFF
--- a/app/views/sign_up_sheet/_actions.html.erb
+++ b/app/views/sign_up_sheet/_actions.html.erb
@@ -1,6 +1,9 @@
 <%= link_to :controller=>'bookmarks', :action=> 'list', :id => topic.id do %>
   <span class="fa-stack fa-md" title='View topic bookmarks'>
     <i class="fa fa-bookmark fa-stack-1x fa-2x"></i>
+    <p class="fa fa-stack-2x fa-inverse" style='font-size: 1.0em; padding-top: 2px; font-weight: bold;'>
+      <%= Bookmark.where(topic_id: topic.id).length.to_s %>
+    </p>
   </span>
 <% end %>
 <%= link_to :controller=>'bookmarks', :action=> 'new', :id => topic.id , :assignment_id => params[:assignment_id] do %>


### PR DESCRIPTION
Show bookmark count from topic sign up sheet. This way a user can see if there are any bookmarks without clicking on the link to view them all.